### PR TITLE
port kpengboys patch to fix the cpu count bug

### DIFF
--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -1631,10 +1631,10 @@ void Main_Window::Update_Disabled_Controls() {
   // Apply emulator
 
   // CPU
-  disconnect(ui.CB_CPU_Count, SIGNAL(editTextChanged(const QString &)), this,
-             SLOT(Validate_CPU_Count(const QString &)));
+  disconnect(ui.CB_CPU_Count, SIGNAL(editTextChanged(const QString &)),
+             this, SLOT(Validate_CPU_Count(const QString &)));
 
-  ui.CB_CPU_Count->clear();
+  //ui.CB_CPU_Count->clear();
 
   if (curComp.PSO_SMP_Count == 1) {
     ui.CB_CPU_Count->addItem(QString::number(1));


### PR DESCRIPTION
see: https://github.com/kpengboy/aqemu/commit/aed251fb7546d2986e0a2b1d3c01dcc462069865
which shows the "Current VM was changed. Save all changes?" dialogbox
when a user switches from on vm to another or when aqemu is closed

Signed-off-by: Peter Wagner <tripolar@gmx.at>